### PR TITLE
Use WOF-mapped nlsfi importer

### DIFF
--- a/scripts/getdata.sh
+++ b/scripts/getdata.sh
@@ -42,7 +42,7 @@ install_node_project HSLdevcom wof-pip-service
 install_node_project HSLdevcom wof-admin-lookup
 npm link pelias-wof-pip-service
 
-install_node_project hsldevcom openstreetmap
+install_node_project pelias openstreetmap
 npm link pelias-dbclient
 npm link pelias-wof-admin-lookup
 

--- a/scripts/getdata.sh
+++ b/scripts/getdata.sh
@@ -72,28 +72,20 @@ $SCRIPTS/osm-loader.sh &
 $SCRIPTS/nlsfi-loader.sh &
 $SCRIPTS/gtfs-loader.sh &
 
+#launch also Elasticsearch at this point
+$SCRIPTS/start-ES.sh &
+
 #sync
 wait
 
 ok_count=$(cat /tmp/loadresults | grep 'OK' | wc -l )
-if [ $ok_count -ne 4 ]; then
+if [ $ok_count -ne 5 ]; then
     exit 1;
 fi
-
-cd /root
 
 #=================
 # Index everything
 #=================
-
-#start elasticsearch, create index and run importers
-gosu elasticsearch elasticsearch -d
-
-sleep 10
-
-#schema script runs only from current dir
-cd $TOOLS/schema/
-node scripts/create_index
 
 #run two imports in parallel to save time
 $SCRIPTS/index1.sh &

--- a/scripts/getdata.sh
+++ b/scripts/getdata.sh
@@ -42,7 +42,7 @@ install_node_project HSLdevcom wof-pip-service
 install_node_project HSLdevcom wof-admin-lookup
 npm link pelias-wof-pip-service
 
-install_node_project pelias openstreetmap
+install_node_project hsldevcom openstreetmap
 npm link pelias-dbclient
 npm link pelias-wof-admin-lookup
 

--- a/scripts/index1.sh
+++ b/scripts/index1.sh
@@ -20,7 +20,7 @@ do
     import_gtfs $target
 done
 
-node $TOOLS/pelias-nlsfi-places-importer/lib/index -d $DATA/nls-places
+node --max-old-space-size=6200 $TOOLS/pelias-nlsfi-places-importer/lib/index -d $DATA/nls-places
 node $TOOLS/polylines/bin/cli.js --config --db
 node $TOOLS/openstreetmap/index
 

--- a/scripts/index1.sh
+++ b/scripts/index1.sh
@@ -8,7 +8,9 @@ set -e
 # param: zip name containing gtfs data
 function import_gtfs {
     unzip -o $1
-    node $TOOLS/pelias-gtfs/import -d $DATA/router-finland
+    prefix=$(echo $1 | sed 's/.zip//g')
+    prefix=${prefix^^}
+    node $TOOLS/pelias-gtfs/import -d $DATA/router-finland -prefix $prefix
 }
 
 cd $DATA/router-finland

--- a/scripts/index1.sh
+++ b/scripts/index1.sh
@@ -10,7 +10,7 @@ function import_gtfs {
     unzip -o $1
     prefix=$(echo $1 | sed 's/.zip//g')
     prefix=${prefix^^}
-    node $TOOLS/pelias-gtfs/import -d $DATA/router-finland -prefix $prefix
+    node $TOOLS/pelias-gtfs/import -d $DATA/router-finland --prefix=$prefix
 }
 
 cd $DATA/router-finland

--- a/scripts/index1.sh
+++ b/scripts/index1.sh
@@ -21,7 +21,5 @@ do
 done
 
 node --max-old-space-size=6200 $TOOLS/pelias-nlsfi-places-importer/lib/index -d $DATA/nls-places
-node $TOOLS/polylines/bin/cli.js --config --db
-node $TOOLS/openstreetmap/index
 
 echo 'OK' >> /tmp/indexresults

--- a/scripts/index2.sh
+++ b/scripts/index2.sh
@@ -11,4 +11,7 @@ node $TOOLS/openaddresses/import --language=sv
 # then import and merge fi data with sv docs
 node $TOOLS/openaddresses/import --language=fi --merge --merge-fields=name
 
+node $TOOLS/polylines/bin/cli.js --config --db
+node $TOOLS/openstreetmap/index
+
 echo 'OK' >> /tmp/indexresults

--- a/scripts/start-ES.sh
+++ b/scripts/start-ES.sh
@@ -1,0 +1,17 @@
+#!/bin/bash
+
+# errors should break the execution
+set -e
+
+cd /root
+
+#start elasticsearch, create index and run importers
+gosu elasticsearch elasticsearch -d
+
+sleep 20
+
+#schema script runs only from current dir
+cd $TOOLS/schema/
+node scripts/create_index
+
+echo 'OK' >> /tmp/loadresults


### PR DESCRIPTION
WOF mapping makes nlsfi import slow, so import scripts have been redivided. Also new import params added. 
