### PR TITLE
DT-2018

### DIFF
--- a/scripts/gtfs-loader.sh
+++ b/scripts/gtfs-loader.sh
@@ -10,5 +10,9 @@ cd $DATA
 curl -sS -O http://dev-api.digitransit.fi/routing-data/v1/$NAME
 unzip $NAME
 
+NAME=router-waltti.zip
+curl -sS -O http://dev-api.digitransit.fi/routing-data/v1/$NAME
+unzip $NAME
+
 echo '##### Loaded GTFS data'
 echo 'OK' >> /tmp/loadresults

--- a/scripts/index2.sh
+++ b/scripts/index2.sh
@@ -6,17 +6,26 @@ set -e
 # param: zip name containing gtfs data
 function import_gtfs {
     unzip -o $1
-    prefix=$(echo $1 | sed 's/.zip//g')
+
+    # extract feed id
+    index=$(sed -n $'1s/,/\\\n/gp' feed_info.txt | grep -nx 'feed_id' | cut -d: -f1)
+    prefix=$(cat feed_info.txt | sed -n 2p | cut -d "," -f $index)
     prefix=${prefix^^}
     node $TOOLS/pelias-gtfs/import -d $DATA/router-finland --prefix=$prefix
 }
 
-cd $DATA/router-finland
-targets=(`ls *.zip`)
-for target in "${targets[@]}"
-do
-    import_gtfs $target
-done
+function import_router {
+    cd $DATA/$1
+    targets=(`ls *.zip`)
+    for target in "${targets[@]}"
+    do
+        import_gtfs $target
+    done
+}
+
+import_router router-finland
+import_router router-waltti
+
 echo '###### gtfs done'
 
 #import openaddresses data


### PR DESCRIPTION
Import gtfs from waltti and finland, prefix source by feedid, not by gtfs file name. Stop search from pelias can now be selective in all cities using the feedid as filter. 
