### PR TITLE
Allow stdout direction with tee

### DIFF
--- a/scripts/build-base.sh
+++ b/scripts/build-base.sh
@@ -16,9 +16,11 @@ DOCKER_TAGGED_IMAGE=$ORG/$DOCKER_IMAGE:$DOCKER_TAG
 # Build image
 docker build -t="$DOCKER_TAGGED_IMAGE" -f Dockerfile.base .
 
-docker login -u $DOCKER_USER -p $DOCKER_AUTH
-docker push $ORG/$DOCKER_IMAGE:$DOCKER_TAG
-docker tag $ORG/$DOCKER_IMAGE:$DOCKER_TAG $ORG/$DOCKER_IMAGE:latest
-docker push $ORG/$DOCKER_IMAGE:latest
+if [ "${TRAVIS_PULL_REQUEST}" == "false" ]; then
+    docker login -u $DOCKER_USER -p $DOCKER_AUTH
+    docker push $ORG/$DOCKER_IMAGE:$DOCKER_TAG
+    docker tag $ORG/$DOCKER_IMAGE:$DOCKER_TAG $ORG/$DOCKER_IMAGE:latest
+    docker push $ORG/$DOCKER_IMAGE:latest
+fi
 
 echo "$DOCKER_IMAGE built and deployed"

--- a/scripts/build-builder.sh
+++ b/scripts/build-builder.sh
@@ -16,9 +16,11 @@ DOCKER_TAGGED_IMAGE=$ORG/$DOCKER_IMAGE:$DOCKER_TAG
 # Build image
 docker build -t="$DOCKER_TAGGED_IMAGE" -f Dockerfile.builder .
 
-docker login -u $DOCKER_USER -p $DOCKER_AUTH
-docker push $ORG/$DOCKER_IMAGE:$DOCKER_TAG
-docker tag $ORG/$DOCKER_IMAGE:$DOCKER_TAG $ORG/$DOCKER_IMAGE:latest
-docker push $ORG/$DOCKER_IMAGE:latest
+if [ "${TRAVIS_PULL_REQUEST}" == "false" ]; then
+    docker login -u $DOCKER_USER -p $DOCKER_AUTH
+    docker push $ORG/$DOCKER_IMAGE:$DOCKER_TAG
+    docker tag $ORG/$DOCKER_IMAGE:$DOCKER_TAG $ORG/$DOCKER_IMAGE:latest
+    docker push $ORG/$DOCKER_IMAGE:latest
+fi
 
 echo "$DOCKER_IMAGE built and deployed"

--- a/scripts/build-data-container.sh
+++ b/scripts/build-data-container.sh
@@ -100,6 +100,8 @@ function test_container {
     ENDPOINT='    "endpoints": { "local": "http://'$HOST':8080/v1/" }'
     sed -i "/endpoints/c $ENDPOINT" $PELIAS_CONFIG
 
+    RESULT=1
+
     for (( c=1; c<=$ITERATIONS; c++ ));do
         STATUS_CODE=$(curl -s -o /dev/null -w "%{http_code}" http://$HOST:8080/v1)
 
@@ -114,18 +116,19 @@ function test_container {
 
             if [ $RESULT -ne 0 ]; then
                 echo "ERROR: Tests did not pass"
-                return 1
             else
                 echo -e "\nTests passed\n"
-                return 0
             fi
+            break
         else
             echo "waiting for service ..."
             sleep 10
         fi
     done
 
-    return 1
+    shutdown
+
+    return $RESULT
 }
 
 echo "Launching geocoding data builder service" | tee log.txt
@@ -148,7 +151,6 @@ while true; do
         echo "New container built. Testing next... "
         ( test_container $DOCKER_TAGGED_IMAGE &>> log.txt )
         RESULT=$?
-        shutdown
 
         if [ $RESULT -eq 0 ]; then
             echo "Container passed tests. Deploying ..."

--- a/scripts/build-data-container.sh
+++ b/scripts/build-data-container.sh
@@ -68,7 +68,7 @@ function deploy {
     docker tag $DOCKER_TAGGED_IMAGE $ORG/$DOCKER_IMAGE:latest
     docker push $ORG/$DOCKER_IMAGE:latest
     docker tag $DOCKER_TAGGED_IMAGE $ORG/$DOCKER_IMAGE:prod
-    #docker push $ORG/$DOCKER_IMAGE:prod
+    docker push $ORG/$DOCKER_IMAGE:prod
 }
 
 function shutdown {

--- a/scripts/build-data-container.sh
+++ b/scripts/build-data-container.sh
@@ -149,12 +149,12 @@ while true; do
     ( build $DOCKER_TAGGED_IMAGE 2>&1 |tee log.txt )
     if [ $? -eq 0 ]; then
         echo "New container built. Testing next... "
-        ( test_container $DOCKER_TAGGED_IMAGE 2>&1 |tee -a log.txt )
+        ( test_container $DOCKER_TAGGED_IMAGE 2>&1 | tee -a log.txt )
         RESULT=$?
 
         if [ $RESULT -eq 0 ]; then
             echo "Container passed tests. Deploying ..."
-            ( deploy $DOCKER_TAGGED_IMAGE 2>&1 |tee log.txt )
+            ( deploy $DOCKER_TAGGED_IMAGE 2>&1 | tee -a log.txt )
             if [ $? -eq 0 ]; then
                 echo "Container deployed"
                 SUCCESS=1

--- a/scripts/build-data-container.sh
+++ b/scripts/build-data-container.sh
@@ -143,16 +143,16 @@ while true; do
 
     SUCCESS=0
     echo "Building new container..."
-    ( build $DOCKER_TAGGED_IMAGE &> log.txt )
+    ( build $DOCKER_TAGGED_IMAGE 2>&1 |tee log.txt )
     if [ $? -eq 0 ]; then
         echo "New container built. Testing next... "
-        ( test_container $DOCKER_TAGGED_IMAGE &>> log.txt )
+        ( test_container $DOCKER_TAGGED_IMAGE 2>&1 |tee -a log.txt )
         RESULT=$?
         shutdown
 
         if [ $RESULT -eq 0 ]; then
             echo "Container passed tests. Deploying ..."
-            ( deploy $DOCKER_TAGGED_IMAGE &>> log.txt )
+            ( deploy $DOCKER_TAGGED_IMAGE 2>&1 |tee log.txt )
             if [ $? -eq 0 ]; then
                 echo "Container deployed"
                 SUCCESS=1

--- a/scripts/build-data-container.sh
+++ b/scripts/build-data-container.sh
@@ -68,7 +68,7 @@ function deploy {
     docker tag $DOCKER_TAGGED_IMAGE $ORG/$DOCKER_IMAGE:latest
     docker push $ORG/$DOCKER_IMAGE:latest
     docker tag $DOCKER_TAGGED_IMAGE $ORG/$DOCKER_IMAGE:prod
-    docker push $ORG/$DOCKER_IMAGE:prod
+    #docker push $ORG/$DOCKER_IMAGE:prod
 }
 
 function shutdown {


### PR DESCRIPTION
Capturing stdout to a log file with tee hung because tested docker containers continued running as sub processes.   Now the containers are shut down before the test process exits. 

