### PR TITLE
Remove built image after deploy

### DIFF
--- a/scripts/build-data-container.sh
+++ b/scripts/build-data-container.sh
@@ -176,6 +176,8 @@ while true; do
         fi
     fi
 
+    docker rmi $DOCKER_TAGGED_IMAGE
+
     if [ $SUCCESS -eq 0 ]; then
         echo "ERROR: Build failed"
         #extract log end which most likely contains info about failure


### PR DESCRIPTION
New data container must be deleted afterwards, otherwise docker caching will duplicate it in the next build round (caching cannot detect dynamically changing content, of course).  

