### PR TITLE
Fail earlier in data build errors

### DIFF
--- a/scripts/dl-and-index.sh
+++ b/scripts/dl-and-index.sh
@@ -12,6 +12,8 @@
 
 # errors should break the execution
 
+set -e
+
 SCRIPTS=${SCRIPTS:-$TOOLS/scripts}
 
 #schema script runs only from current dir

--- a/scripts/gtfs-loader.sh
+++ b/scripts/gtfs-loader.sh
@@ -9,12 +9,12 @@ URL="http://dev-api.digitransit.fi/routing-data/v2/"
 SERVICE="finland/"
 NAME="router-finland.zip"
 cd $DATA
-curl -sS -O $URL$SERVICE$NAME
+curl -sS -O --fail $URL$SERVICE$NAME
 unzip -o $NAME
 
 SERVICE="waltti/"
 NAME="router-waltti.zip"
-curl -sS -O $URL$SERVICE$NAME
+curl -sS -O --fail $URL$SERVICE$NAME
 unzip -o $NAME
 
 echo '##### Loaded GTFS data'

--- a/scripts/nlsfi-loader.sh
+++ b/scripts/nlsfi-loader.sh
@@ -14,7 +14,7 @@ NAME=$(curl -Ss $URL | grep -o 'href=".*zip"' | sort -r | head -1 | sed 's/\(hre
 echo 'Loading nlsfi data from' $URL$NAME
 
 # Download nls paikat data
-curl -sS -O $URL$NAME
+curl -sS -O --fail $URL$NAME
 unzip -o $NAME
 rm $NAME
 

--- a/scripts/oa-loader.sh
+++ b/scripts/oa-loader.sh
@@ -8,7 +8,7 @@ cd $DATA/openaddresses
 
 # Download all '/fi/' entries from OpenAddresses
 # state.txt describes netries, but urls must be transformed to point to reliable amazonaws and scandic 'ä' urlencoded
-curl -sS http://results.openaddresses.io/state.txt | sed 's/\s\+/\n/g' | grep '/fi/.*\.zip' | sed 's/ä/%C3%A4/g' | sed 's/http:\/\//https:\/\/s3.amazonaws.com\//g' | xargs -n 1 curl -O -sS
+curl -sS --fail http://results.openaddresses.io/state.txt | sed 's/\s\+/\n/g' | grep '/fi/.*\.zip' | sed 's/ä/%C3%A4/g' | sed 's/http:\/\//https:\/\/s3.amazonaws.com\//g' | xargs -n 1 curl -O -sS --fail
 ls *.zip | xargs -n 1 unzip -o
 rm *.zip README.*
 

--- a/scripts/osm-loader.sh
+++ b/scripts/osm-loader.sh
@@ -7,6 +7,6 @@ mkdir -p $DATA/openstreetmap
 cd $DATA/openstreetmap
 
 # Download osm data
-curl -sS -O http://dev.hsl.fi/osm.finland/finland.osm.pbf
+curl -sS -O --fail http://dev.hsl.fi/osm.finland/finland.osm.pbf
 
 echo '##### Loaded OSM data'


### PR DESCRIPTION
- Use  --fail option for curl requests
- set -e was accidentally dropped from the build script, add it back