### PR TITLE
Build containers when a tagged release is made

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,8 +1,10 @@
+
 sudo: required
 
 branches:
   only:
     - master
+    - /201[7-9][0-1][0-9][0-3][0-9]/
 
 services: docker
 


### PR DESCRIPTION
Making a release is the right way to trigger the build when a
dependency changes. Changes in sub repos cannot automatically trigger
travis build so we need a way to start the build.