### PR TITLE
Allow curl to redirect

### DIFF
--- a/scripts/osm-loader.sh
+++ b/scripts/osm-loader.sh
@@ -7,6 +7,6 @@ mkdir -p $DATA/openstreetmap
 cd $DATA/openstreetmap
 
 # Download osm data
-curl -sS -O --fail http://dev.hsl.fi/osm.finland/finland.osm.pbf
+curl -sS -O -L --fail http://dev.hsl.fi/osm.finland/finland.osm.pbf
 
 echo '##### Loaded OSM data'


### PR DESCRIPTION
Because dev.shl.fi redirects to new addr. Geoocoder gets osm data from there.