### PR TITLE
Improve logging

### DIFF
--- a/scripts/gtfs-loader.sh
+++ b/scripts/gtfs-loader.sh
@@ -5,6 +5,8 @@ set -e
 
 # Download gtfs stop data
 
+echo 'Loading GTFS data from api.digitransit.fi...'
+
 URL="http://api.digitransit.fi/routing-data/v2/"
 SERVICE="finland/"
 NAME="router-finland.zip"

--- a/scripts/nlsfi-loader.sh
+++ b/scripts/nlsfi-loader.sh
@@ -3,6 +3,7 @@
 # errors should break the execution
 set -e
 
+echo 'Extracting nlsfi data address...'
 NAME=paikat.zip
 URL=$(node $SCRIPTS/parse_nlsfi_url.js)
 
@@ -10,7 +11,7 @@ mkdir -p $DATA/nls-places
 cd $DATA/nls-places
 
 # Download nls paikat data
-echo 'Loading nlsfi data'
+echo 'Loading nlsfi data...'
 
 wget -O $NAME $URL
 unzip -o $NAME

--- a/scripts/oa-loader.sh
+++ b/scripts/oa-loader.sh
@@ -6,6 +6,7 @@ set -e
 mkdir -p $DATA/openaddresses
 cd $DATA/openaddresses
 
+echo 'Loading OpenAddresses data...'
 # Download all '/fi/' entries from OpenAddresses
 # state.txt describes netries, but urls must be transformed to point to reliable amazonaws and scandic 'ä' urlencoded
 curl -sS --fail http://results.openaddresses.io/state.txt | sed 's/\s\+/\n/g' | grep '/fi/.*\.zip' | sed 's/ä/%C3%A4/g' | sed 's/http:\/\//https:\/\/s3.amazonaws.com\//g' | xargs -n 1 curl -O -sS --fail

--- a/scripts/osm-loader.sh
+++ b/scripts/osm-loader.sh
@@ -6,6 +6,8 @@ set -e
 mkdir -p $DATA/openstreetmap
 cd $DATA/openstreetmap
 
+echo 'Loading OSM data...'
+
 # Download osm data
 curl -sS -O -L --fail https://karttapalvelu.storage.hsldev.com/finland.osm/finland.osm.pbf
 


### PR DESCRIPTION
Data source loading fails always now and then. Add some extra logging
so that it is easy to see immediately from slack posting what actually failed.
Silent curl itself does not tell what actually failed.