### PR TITLE
Improve single run

### DIFF
--- a/Dockerfile.builder
+++ b/Dockerfile.builder
@@ -2,8 +2,6 @@
 
 FROM docker:18.06
 
-ENV DOCKER_API_VERSION ${DOCKER_API_VERSION:-1.23}
-
 WORKDIR /mnt
 
 ADD Dockerfile.loader ${WORKDIR}

--- a/scripts/build-data-container.sh
+++ b/scripts/build-data-container.sh
@@ -262,6 +262,10 @@ while true; do
 
     if [[ "$BUILD_INTERVAL" -le 0 ]]; then
         #run only once
-        exit 0
+        if [ $SUCCESS = 1 ]; then
+            exit 0
+        else
+            exit 1
+        fi
     fi
 done


### PR DESCRIPTION
* Exit process when doing only one build with an appropriate exit code based on if build was successful or not
* Remove DOCKER_API_VERSION env usage because it is no longer needed