### PR TITLE
Sleep longer, try less

### DIFF
--- a/scripts/osm-loader.sh
+++ b/scripts/osm-loader.sh
@@ -9,7 +9,7 @@ echo 'Loading OSM data...'
 
 # allow failures so that curl can be retried many times
 set +e
-for i in $(seq 0 10)
+for i in $(seq 0 4)
 do
     # Download osm data
     curl -sS -O -L --fail https://karttapalvelu.storage.hsldev.com/finland.osm/finland.osm.pbf
@@ -17,7 +17,7 @@ do
         echo '##### Loaded OSM data'
         exit 0
     fi
-    sleep 120
+    sleep 600
 done
 
 # exit with an error


### PR DESCRIPTION
OSM loading failure is not about how many trials is made, but when the trials are made.
This change extends the total waiting of data source recovery from 20 minutes to 40 minutes.