### PR TITLE
Start ES in a correct way + some cleanup

### DIFF
--- a/Dockerfile.base
+++ b/Dockerfile.base
@@ -10,8 +10,9 @@ RUN /bin/bash -c "source /mnt/tools/scripts/install-tools.sh"
 RUN curl -sS -O -L --fail https://artifacts.elastic.co/downloads/elasticsearch/elasticsearch-7.5.2-amd64.deb \
  && curl -sS -O -L --fail https://artifacts.elastic.co/downloads/elasticsearch/elasticsearch-7.5.2-amd64.deb.sha512 \
  && shasum -a 512 -c elasticsearch-7.5.2-amd64.deb.sha512 \
- && dpkg -i elasticsearch-7.5.2-amd64.deb
- && rm elasticsearch-7.5.2-amd64.deb
+ && dpkg -i elasticsearch-7.5.2-amd64.deb \
+ && rm elasticsearch-7.5.2-amd64.deb \
+ && rm elasticsearch-7.5.2-amd64.deb.sha512
 
 # Finalize elasticsearch installation
 ADD config/elasticsearch.yml /usr/share/elasticsearch/config/

--- a/Dockerfile.base
+++ b/Dockerfile.base
@@ -3,7 +3,6 @@
 FROM debian:buster-slim
 MAINTAINER Reittiopas version: 0.1
 
-# Download and index data and do cleanup for temp data + packages
 RUN mkdir -p /mnt/tools/scripts
 ADD scripts/* /mnt/tools/scripts/
 RUN /bin/bash -c "source /mnt/tools/scripts/install-tools.sh"
@@ -12,12 +11,10 @@ RUN curl -sS -O -L --fail https://artifacts.elastic.co/downloads/elasticsearch/e
  && curl -sS -O -L --fail https://artifacts.elastic.co/downloads/elasticsearch/elasticsearch-7.5.2-amd64.deb.sha512 \
  && shasum -a 512 -c elasticsearch-7.5.2-amd64.deb.sha512 \
  && dpkg -i elasticsearch-7.5.2-amd64.deb
+ && rm elasticsearch-7.5.2-amd64.deb
 
 # Finalize elasticsearch installation
 ADD config/elasticsearch.yml /usr/share/elasticsearch/config/
-
-# Add elastisearch-head plugin for browsing ElasticSearch data
-# RUN chmod +wx /usr/share/elasticsearch/plugins/
 RUN /usr/share/elasticsearch/bin/elasticsearch-plugin install analysis-icu
 
 RUN mkdir -p /var/lib/elasticsearch/pelias_data \

--- a/scripts/getdata.sh
+++ b/scripts/getdata.sh
@@ -13,12 +13,13 @@ export SCRIPTS=$TOOLS/scripts
 # Launch Elasticsearch
 cd /root
 
-gosu elasticsearch elasticsearch -d
+service elasticsearch start
 sleep 20
 
 # download and index
 $SCRIPTS/dl-and-index.sh
 
 #shutdown ES in a friendly way
-pkill -SIGTERM -u elasticsearch
+service elasticsearch stop
+
 sleep 3


### PR DESCRIPTION
- Elastic can be nicely started using the service command, no need for gosu tricks.
- Cleanup incorrect comments and outdated  code lines