### PR TITLE
Make verbose step silent

### DIFF
--- a/scripts/build-data-container.sh
+++ b/scripts/build-data-container.sh
@@ -133,7 +133,7 @@ function test_container {
     echo "Shutting down the test services..."
     docker stop $API
     docker stop $DATACONT
-    docker rmi $API_IMAGE
+    docker rmi $API_IMAGE > /dev/null 2>&1
     return $TESTS_PASSED
 }
 


### PR DESCRIPTION
Clearing the api image used in testing flushed out the actual failure message
from the slack message.