### PR TITLE
Download OSM again from karttapalvelu storage

### DIFF
--- a/scripts/gtfs-loader.sh
+++ b/scripts/gtfs-loader.sh
@@ -9,7 +9,6 @@ echo 'Loading GTFS data from api.digitransit.fi...'
 
 cd $DATA
 mkdir -p gtfs
-mkdir -p openstreetmap
 
 URL="http://api.digitransit.fi/routing-data/v2/"
 SERVICE="finland/"

--- a/scripts/gtfs-loader.sh
+++ b/scripts/gtfs-loader.sh
@@ -17,8 +17,6 @@ NAME="router-finland.zip"
 curl -sS -O --fail $URL$SERVICE$NAME
 unzip -o $NAME && rm $NAME
 mv router-finland/*.zip gtfs/
-# use already validated osm data from our own data api
-mv router-finland/*.pbf openstreetmap/
 
 SERVICE="waltti/"
 NAME="router-waltti.zip"

--- a/scripts/osm-loader.sh
+++ b/scripts/osm-loader.sh
@@ -8,9 +8,6 @@ cd $DATA/openstreetmap
 echo 'Loading OSM data...'
 curl -sS -O -L --fail  https://geocoding.blob.core.windows.net/vrk/hsl_geocode_appendix.osm.pbf
 
-# Do not load OSM from unreliable karttapalvelu data service
-exit 0
-
 # allow failures so that curl can be retried many times
 set +e
 for i in $(seq 0 4)


### PR DESCRIPTION
Our own data api sometimes offers old data because OTP deployment tests do not pass