### PR TITLE
DT-5399 index varely gtfs data into geocoding

### DIFF
--- a/scripts/dl-and-index.sh
+++ b/scripts/dl-and-index.sh
@@ -17,6 +17,13 @@ export SCRIPTS=${SCRIPTS:-$TOOLS/scripts}
 cd $TOOLS/pelias-schema/
 node scripts/create_index
 
+if [ $BUILDER_TYPE = "dev" ]; then
+    APIURL="https://dev-api.digitransit.fi/"
+else
+    APIURL="https://api.digitransit.fi/"
+fi
+
+echo "###### Using $APIURL data"
 
 #==============
 # Download data
@@ -61,12 +68,12 @@ function import_router {
 import_router gtfs
 echo '###### gtfs done'
 
-node $TOOLS/bikes-pelias/import https://api.digitransit.fi/routing/v1/routers/finland/index/graphql
-node $TOOLS/bikes-pelias/import https://api.digitransit.fi/routing/v1/routers/waltti/index/graphql
+node $TOOLS/bikes-pelias/import "$APIURL"routing/v1/routers/finland/index/graphql
+node $TOOLS/bikes-pelias/import "$APIURL"routing/v1/routers/waltti/index/graphql
 echo '###### city bike station loading done'
 
-node $TOOLS/parking-areas-pelias/import https://api.digitransit.fi/routing/v1/routers/hsl/index/graphql carPark liipi
-node $TOOLS/parking-areas-pelias/import https://api.digitransit.fi/routing/v1/routers/hsl/index/graphql	bikePark liipi
+node $TOOLS/parking-areas-pelias/import "$APIURL"routing/v1/routers/hsl/index/graphql carPark liipi
+node $TOOLS/parking-areas-pelias/import "$APIURL"routing/v1/routers/hsl/index/graphql bikePark liipi
 echo '###### park & ride location loading done'
 
 node $TOOLS/openstreetmap/index

--- a/scripts/gtfs-loader.sh
+++ b/scripts/gtfs-loader.sh
@@ -15,29 +15,30 @@ DATA_API="http://api.digitransit.fi/routing-data/"
 DEV_DATA_API="http://dev-api.digitransit.fi/routing-data/"
 
 if [ $BUILDER_TYPE = "dev" ]; then
-    URL=$DEV_DATA_API"v2/"
+    URL=$DEV_DATA_API
     WALTTI_ALT_URL=$DEV_DATA_API"v3/waltti-alt/"
 else
-    URL=$DATA_API"v2/"
+    URL=$DATA_API
     WALTTI_ALT_URL=$DATA_API"v3/waltti-alt/"
 fi
 
-# param1: service name
-# param2: optional basic auth string
+# param1: data version, v2 or v3
+# param2: service name
 function load_gtfs {
-    NAME="router-"$1
+    NAME="router-"$2
     ZIPNAME=$NAME.zip
-    curl -sS -O --fail $2 $URL$1/$ZIPNAME
+    curl -sS -O --fail $URL$1/$2/$ZIPNAME
     unzip -o $ZIPNAME && rm $ZIPNAME
     mv $NAME/*.zip gtfs/
 }
 
-load_gtfs finland
+load_gtfs v2 finland
 # use already validated osm data from our own data api
 mv router-finland/*.pbf openstreetmap/
 
-load_gtfs waltti
-load_gtfs hsl
+load_gtfs v2 waltti
+load_gtfs v2 hsl
+load_gtfs v3 varely
 
 if [[ -v GTFS_AUTH ]]; then
     NAME="router-waltti-alt"

--- a/scripts/gtfs-loader.sh
+++ b/scripts/gtfs-loader.sh
@@ -43,7 +43,7 @@ load_gtfs v3 varely
 if [[ -v GTFS_AUTH ]]; then
     NAME="router-waltti-alt"
     ZIPNAME=$NAME.zip
-    curl -sS -O --fail -u $GTFS_AUTH $WALTTI_ALT_URL$ZIPNAME"
+    curl -sS -O --fail -u $GTFS_AUTH $WALTTI_ALT_URL$ZIPNAME
     unzip -o $ZIPNAME && rm $ZIPNAME
     mv $NAME/*.zip gtfs/
 fi

--- a/scripts/gtfs-loader.sh
+++ b/scripts/gtfs-loader.sh
@@ -5,13 +5,22 @@ set -e
 
 # Download gtfs stop data
 
-echo 'Loading GTFS data from api.digitransit.fi...'
+echo 'Loading GTFS data from digitransit api...'
 
 cd $DATA
 mkdir -p gtfs
 mkdir -p openstreetmap
 
-URL="http://api.digitransit.fi/routing-data/v2/"
+DATA_API="http://api.digitransit.fi/routing-data/"
+DEV_DATA_API="http://dev-api.digitransit.fi/routing-data/"
+
+if [ $BUILDER_TYPE = "dev" ]; then
+    URL=$DEV_DATA_API"v2/"
+    WALTTI_ALT_URL=$DEV_DATA_API"v3/waltti-alt/"
+else
+    URL=$DATA_API"v2/"
+    WALTTI_ALT_URL=$DATA_API"v3/waltti-alt/"
+fi
 
 # param1: service name
 # param2: optional basic auth string
@@ -33,7 +42,7 @@ load_gtfs hsl
 if [[ -v GTFS_AUTH ]]; then
     NAME="router-waltti-alt"
     ZIPNAME=$NAME.zip
-    curl -sS -O --fail -u $GTFS_AUTH "http://dev-api.digitransit.fi/routing-data/v3/waltti-alt/$ZIPNAME"
+    curl -sS -O --fail -u $GTFS_AUTH $WALTTI_ALT_URL$ZIPNAME"
     unzip -o $ZIPNAME && rm $ZIPNAME
     mv $NAME/*.zip gtfs/
 fi

--- a/scripts/gtfs-loader.sh
+++ b/scripts/gtfs-loader.sh
@@ -11,15 +11,15 @@ cd $DATA
 mkdir -p gtfs
 mkdir -p openstreetmap
 
-DATA_API="http://api.digitransit.fi/routing-data/"
-DEV_DATA_API="http://dev-api.digitransit.fi/routing-data/"
+DATA_API="https://api.digitransit.fi/routing-data/"
+DEV_DATA_API="https://dev-api.digitransit.fi/routing-data/"
 
 if [ $BUILDER_TYPE = "dev" ]; then
     URL=$DEV_DATA_API
-    WALTTI_ALT_URL=$DEV_DATA_API"v3/waltti-alt/"
+    WALTTI_ALT_URL="$DEV_DATA_API"v3/waltti-alt/
 else
     URL=$DATA_API
-    WALTTI_ALT_URL=$DATA_API"v3/waltti-alt/"
+    WALTTI_ALT_URL="$DATA_API"v3/waltti-alt/
 fi
 
 # param1: data version, v2 or v3


### PR DESCRIPTION
This PR can be merged after varely data container is deployed into development. Note that new geocoding data builder can be released only after varely prod deployments.

In this PR, digitransit starts using dev-api data for dev geocoding, so that varely data can be found before it gets deployed to production. This improves overall quality of dev services, because temporary data sources become available in address search.