### PR TITLE
DT-5910 Use node 16 and python 3

### DIFF
--- a/Dockerfile.pelias-data-container-builder
+++ b/Dockerfile.pelias-data-container-builder
@@ -8,11 +8,10 @@ ADD Dockerfile.loader ${WORKDIR}
 ADD scripts/build-data-container.sh ${WORKDIR}
 ADD pelias.json ${WORKDIR}
 
-RUN apk add --no-cache alpine-sdk bash bc curl git jq python2 sed grep coreutils nodejs nodejs-npm
+RUN apk add --no-cache alpine-sdk bash bc curl git jq python sed grep coreutils nodejs nodejs-npm
 
 RUN git clone --single-branch https://github.com/hsldevcom/pelias-fuzzy-tests \
   && cd pelias-fuzzy-tests \
   && npm install
 
 CMD ( dockerd-entrypoint.sh & ) && sleep 40 && unset DOCKER_HOST && /bin/bash /mnt/build-data-container.sh
-

--- a/scripts/install-tools.sh
+++ b/scripts/install-tools.sh
@@ -33,7 +33,7 @@ rm -rf /var/lib/apt/lists/*
 
 mkdir -p $SCRIPTS
 
-curl -sL https://deb.nodesource.com/setup_10.x | bash -
+curl -sL https://deb.nodesource.com/setup_16.x | bash -
 apt-get install -y --no-install-recommends nodejs
 
 cd $SCRIPTS


### PR DESCRIPTION
- Python 2 was required by fuzzy-tester's old sleep library, which is now updated.
- Node 16 did not work because of wof-admin-lookup->whosonfirst->better-sqlite3 dependency chain, which  broke node-gyp builds. Hsldecom now hosts a backward compatible whosonfirst repo, which uses node16 compatible better-sqlite3 version.