### PR TITLE
DT-6349 external blacklist for geocoding

### DIFF
--- a/pelias.json
+++ b/pelias.json
@@ -33,6 +33,7 @@
     "endpoints": { "local": "http://localhost:3100/v1/" }
   },
   "imports": {
+    "blacklistUrl": "https://geocoding.blob.core.windows.net/vrk/blacklist.txt",
     "blacklist": ["mml-10012934", "mml-12011355", "mml-12002598", "relation:13410240", "relation:34914", "node:59631552", "way:395604698", "node:9770559599", "node:2098884693", "node:10240591962", "node:2005331907", "way:121861337", "node:5730435574"],
     "defaultAdminLayers": ["localadmin", "locality", "neighbourhood", "region", "postalcode", "country"],
     "defaultCountry": {

--- a/scripts/dl-and-index.sh
+++ b/scripts/dl-and-index.sh
@@ -17,6 +17,9 @@ export SCRIPTS=${SCRIPTS:-$TOOLS/scripts}
 cd $TOOLS/pelias-schema/
 node scripts/create_index
 
+cd $SCRIPTS/
+node fetchBlackList.js
+
 if [ "$BUILDER_TYPE" = "dev" ]; then
     APIURL="https://dev-api.digitransit.fi/"
 else

--- a/scripts/fetchBlackList.js
+++ b/scripts/fetchBlackList.js
@@ -1,0 +1,30 @@
+const axios = require('axios');
+const fs = require('fs');
+const confPath = '/root/pelias.json'; // conf path in docker container
+const data = fs.readFileSync(confPath);
+const config = JSON.parse(data);
+const {parse} = require('csv-parse/sync');
+const url = config.imports.blacklistUrl;
+
+if(url && fs.existsSync(confPath)) {
+  if (!config.imports.blacklist) {
+    config.imports.blacklist = [];
+  }
+  console.log('Fetching blacklist from ' + url);
+  axios.get(url)
+    .then(function (response) {
+      const rows = parse(response.data, {
+	trim: true,
+	delimiter: ',',
+	relax_column_count: true,
+	skip_empty_lines: true
+      })
+      rows.forEach(row => {
+	config.imports.blacklist.push(row[0]);
+      });
+      fs.writeFileSync(confPath, JSON.stringify(config, null, 2), 'utf8');
+      console.log('Blacklist updated');
+    }).catch(err => {
+      console.error(err);
+    })
+}

--- a/scripts/package.json
+++ b/scripts/package.json
@@ -4,8 +4,10 @@
   "author": "digitransit",
   "version": "0.0.0",
   "dependencies": {
-    "request": "2.88.0",
-    "feedparser": "2.2.9"
+    "csv-parse": "^5.5.6",
+    "feedparser": "2.2.9",
+    "axios": "1.6.7",
+    "request": "2.88.0"
   },
   "license": "MIT",
   "engines": {


### PR DESCRIPTION
We often need to remove some undesired items from geocoding:  documents with a bad location like airport center etc. 

So far, updating the filter list has required a configuration change and a new data loader release. This is far too heavy and slow process.

This PR adds a new step into dataloading. Blacklist appendix is fetched from a configured address.  Appendix has simple format: a text file where every row contains document id and an optional comment separated with a comma.

"mml-10012934",  "Badly located suburb"
"way:114096769", "Tampere airport  with center on a runway"
"way:121861337",  "Savilahti lake bay in Kuopio"